### PR TITLE
Apply composer settings/caches from home folder into container

### DIFF
--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -21,10 +21,9 @@ services:
     volumes_from:
       - code
     volumes:
-      - "./.composer:/root/.composer"
+      - "~/.composer:/root/.composer"
     environment:
       COMPOSER_ALLOW_SUPERUSER: 1
-      COMPOSER_AUTH: '{ "github-oauth": { "github.com": "$GITHUB_PERSONAL_ACCESS_KEY" } }'
     env_file:
       - ./env/symfony.env
 

--- a/infrastructure/env/docker.env.dist
+++ b/infrastructure/env/docker.env.dist
@@ -16,6 +16,3 @@ export SYMFONY_APP_DOMAIN=dev.symfony
 # base auth user:password for nginx - by default needed only for stg environment
 export SYMFONY_BASE_AUTH_USER=user
 export SYMFONY_BASE_AUTH_PASSWORD=password
-
-# composer auth
-export GITHUB_PERSONAL_ACCESS_KEY={your personal access key generated at github.com}


### PR DESCRIPTION
Navrhujem nahradit sucasny mechanizmus s composer klucmi inym mechanizmom - aplikovanie composer nastaveni z hostu na kontajnery. Vyhody:

- Uz netreba ten kluc nastavit pre kazdy projekt zvlast, staci to nastavit raz a pri setupe kazdeho projektu by to malo fungovat automaticky, bez setnutia environmentalne premennej
- Po rebuildnuti kontajneru z cisteho stavu su vsetky balicky uz nacachovane, netreba to po kazdom cistom builde odznova stahovat - opat - globalne aplikovane pre vsetky projekty