### PR TITLE
Remove exports from env file. It's env, not a script

### DIFF
--- a/infrastructure/env/docker.env.dist
+++ b/infrastructure/env/docker.env.dist
@@ -1,22 +1,22 @@
 # environment - dev|stg|prod
-export DOCKER_INFRASTRUCTURE_ENV=dev
+DOCKER_INFRASTRUCTURE_ENV=dev
 
 # port where the nginx is listening
-export DOCKER_NGINX_PORT=80
+DOCKER_NGINX_PORT=80
 
 # domain which will be nginx listen for
-export NGINX_DOMAIN=dev.symfony
+NGINX_DOMAIN=dev.symfony
 
 # base auth user:password for nginx - by default needed only for stg environment
-export NGINX_BASE_AUTH_USER=user
-export NGINX_BASE_AUTH_PASSWORD=password
+NGINX_BASE_AUTH_USER=user
+NGINX_BASE_AUTH_PASSWORD=password
 
 # adminer
-export DOCKER_ADMINER_PORT=8080
+DOCKER_ADMINER_PORT=8080
 
 # mysql
-export DOCKER_DB_ROOT_PASSWORD=root
-export DOCKER_DB_PORT=3306
+DOCKER_DB_ROOT_PASSWORD=root
+DOCKER_DB_PORT=3306
 
 # elastic
-export DOCKER_ES_PORT=9200
+DOCKER_ES_PORT=9200

--- a/ops
+++ b/ops
@@ -16,8 +16,8 @@ if [ ! -f ./infrastructure/env/docker.env ]; then
 fi
 
 # source env files
-source ./infrastructure/env/docker.env
 set -a
+source ./infrastructure/env/docker.env
 source ./infrastructure/env/symfony.env
 set +a
 


### PR DESCRIPTION
This makes it unable to import these into docker container via docker-compose env_file option.